### PR TITLE
Remove `uuid` dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,7 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 
-gem 'uuid'
-gem "rails", ">= 3.0.12"
+gemspec
 
 group :test do
-  # For testing the formtastic input.  Not required, we won't add the
-  # input if it doesn't exist
-  gem 'formtastic'
+  gem "formtastic"
 end
-

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,11 @@
+PATH
+  remote: .
+  specs:
+    file_upload_cache (1.0.5)
+      rails (>= 3.0.12)
+
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     abstract (1.0.0)
     actionmailer (3.0.12)
@@ -35,9 +41,7 @@ GEM
     formtastic (2.1.1)
       actionpack (~> 3.0)
     i18n (0.5.0)
-    json (1.6.6)
-    macaddr (1.5.0)
-      systemu (>= 2.4.0)
+    json (1.8.1)
     mail (2.2.19)
       activesupport (>= 2.3.6)
       i18n (>= 0.4.0)
@@ -64,22 +68,18 @@ GEM
       rake (>= 0.8.7)
       rdoc (~> 3.4)
       thor (~> 0.14.4)
-    rake (0.9.2.2)
+    rake (10.1.0)
     rdoc (3.12)
       json (~> 1.4)
-    systemu (2.5.0)
     thor (0.14.6)
     treetop (1.4.10)
       polyglot
       polyglot (>= 0.3.1)
     tzinfo (0.3.32)
-    uuid (2.3.5)
-      macaddr (~> 1.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  file_upload_cache!
   formtastic
-  rails (>= 3.0.12)
-  uuid

--- a/app/models/file_upload_cache/cached_file.rb
+++ b/app/models/file_upload_cache/cached_file.rb
@@ -9,13 +9,13 @@ module FileUploadCache
     end
 
     def self.store(image)
-      id = UUID.generate(:compact)
-      cached_file = self.new(:read              => image.read, 
-                             :original_filename => image.respond_to?(:original_filename) ? image.original_filename : nil, 
-                             :id                => id, 
+      id = SecureRandom.hex
+      cached_file = self.new(:read              => image.read,
+                             :original_filename => image.respond_to?(:original_filename) ? image.original_filename : nil,
+                             :id                => id,
                              :content_type      => image.respond_to?(:content_type) ? image.content_type : nil)
 
-      FileUploadCache.file_cache.write("FileUploadCache::#{id}", cached_file) 
+      FileUploadCache.file_cache.write("FileUploadCache::#{id}", cached_file)
 
       cached_file
     end

--- a/file_upload_cache.gemspec
+++ b/file_upload_cache.gemspec
@@ -7,6 +7,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,lib,config}/**/*"] + ["Rakefile", "Gemfile"]
   s.version = "1.0.5"
   s.authors = ['Ken Mazaika']
-  s.add_dependency 'uuid'
-  s.add_dependency 'rails'
+
+  s.add_dependency "rails", ">= 3.0.12"
+  s.add_development_dependency "formtastic"
 end

--- a/file_upload_cache.gemspec
+++ b/file_upload_cache.gemspec
@@ -2,8 +2,9 @@
 # project in your rails apps through git.
 Gem::Specification.new do |s|
   s.name = "file_upload_cache"
-  s.summary = "Insert FileUploadCache summary."
-  s.description = "Insert FileUploadCache description."
+  s.summary = "Restore file uploads after validation errors."
+  s.description = "Restore file uploads after validation errors."
+  s.license = "MIT"
   s.files = Dir["{app,lib,config}/**/*"] + ["Rakefile", "Gemfile"]
   s.version = "1.0.5"
   s.authors = ['Ken Mazaika']

--- a/lib/file_upload_cache.rb
+++ b/lib/file_upload_cache.rb
@@ -1,7 +1,7 @@
 require 'file_upload_cache/engine.rb'
 require 'active_support/core_ext/module/attribute_accessors.rb'
 require 'file_upload_cache/cached_attributes.rb'
-require 'uuid'
+require 'securerandom'
 
 module FileUploadCache
   mattr_accessor :cache

--- a/test/functionals/file_upload_cache/cached_files_controller_test.rb
+++ b/test/functionals/file_upload_cache/cached_files_controller_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class FileUploadCache::CachedFilesControllerTest < ActionController::TestCase
   test "show not found" do
-    nonexistant_id = UUID.generate(:compact)
+    nonexistant_id = "invalid-id"
     get :show, :id => nonexistant_id
     assert_response :not_found
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,8 +1,8 @@
 Dir.chdir File.expand_path('../..', __FILE__)
 ENV['RAILS_ENV'] = 'test'
-require 'rubygems'
 require 'bundler'
 require 'active_record'
+
 begin
   Bundler.setup(:default, :development)
 rescue Bundler::BundlerError => e
@@ -10,18 +10,9 @@ rescue Bundler::BundlerError => e
   $stderr.puts "Run `bundle install` to install missing gems"
   exit e.status_code
 end
+
 require 'tester/config/environment'
 require 'rails/test_help'
-
-
-
-begin
-  Bundler.setup(:default, :development)
-rescue Bundler::BundlerError => e
-  $stderr.puts e.message
-  $stderr.puts "Run `bundle install` to install missing gems"
-  exit e.status_code
-end
 require 'minitest/unit'
 
 $LOAD_PATH.unshift(File.dirname(__FILE__))
@@ -69,7 +60,7 @@ class MockOmg
   include ActiveModel::Validations
   extend  ActiveModel::Callbacks
 
-  define_model_callbacks :validation 
+  define_model_callbacks :validation
 
   attr_reader   :omg_file, :omg_file_data
 

--- a/test/units/lib/file_upload_cache/cached_attributes_test.rb
+++ b/test/units/lib/file_upload_cache/cached_attributes_test.rb
@@ -9,7 +9,7 @@ module FileUploadCache
       assert_equal nil, omg.omg_file_cache_id
       assert_equal nil, omg.cached_omg_file
 
-      uuid = UUID.generate(:compact)
+      uuid = SecureRandom.hex
       omg.omg_file_cache_id = uuid
       assert_equal uuid, omg.omg_file_cache_id
 
@@ -25,7 +25,7 @@ module FileUploadCache
     def test_alias_method_chain_will_cache_value_set_for_field
       omg = MockOmg.new
 
-      file = TestMultipartFile.new(File.open(File.expand_path('test/fixtures/sadface.jpg'))) 
+      file = TestMultipartFile.new(File.open(File.expand_path('test/fixtures/sadface.jpg')))
       omg.omg_file = file
       assert_equal file.read, omg.omg_file_data
       assert_equal file, omg.instance_eval { @omg_file_original }
@@ -38,7 +38,7 @@ module FileUploadCache
 
     def test_validation_stores_item_in_cache
       omg = MockOmg.new
-      file = TestMultipartFile.new(File.open(File.expand_path('test/fixtures/sadface.jpg'))) 
+      file = TestMultipartFile.new(File.open(File.expand_path('test/fixtures/sadface.jpg')))
       omg.omg_file = file
 
       cached_file = omg.cached_omg_file
@@ -48,7 +48,7 @@ module FileUploadCache
 
       cached_file = omg.cached_omg_file
       assert cached_file.is_a?(FileUploadCache::CachedFile)
-      
+
       assert ! cached_file.id.blank?
       fetched_cached_file = FileUploadCache::CachedFile.find(cached_file.id)
       assert_equal cached_file, fetched_cached_file
@@ -76,8 +76,8 @@ module FileUploadCache
     end
 
     def test_validation_restores_item_from_cache_id
-      file = TestMultipartFile.new(File.open(File.expand_path('test/fixtures/sadface.jpg'))) 
-      cached_file = FileUploadCache::CachedFile.store(file)      
+      file = TestMultipartFile.new(File.open(File.expand_path('test/fixtures/sadface.jpg')))
+      cached_file = FileUploadCache::CachedFile.store(file)
       assert ! cached_file.id.nil?
 
       omg = MockOmg.new


### PR DESCRIPTION
The `uuid` gem brings several dependencies along with it, and was only being used to generate a 32-character random string. `SecureRandom` can do the same thing and is in the standard library since `1.9.x`.

There is some extraneous whitespace removal, and I also tidied up the gemspec while I was in here.
